### PR TITLE
Skip configure ceph if unit is not leader

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -322,6 +322,10 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
             event.defer()
             return
 
+        if not self.unit.is_leader():
+            logger.debug("Skipping configure ceph as this unit is not leader")
+            return
+
         default_rf = self.model.config.get("default-pool-size")
         try:
             microceph.set_pool_size("", str(default_rf))


### PR DESCRIPTION
Skip running configure ceph steps if unit is
not leader. Configuring steps on leader unit
is good enough.

# Description

Changing charm default-pool-size will run setting ceph configure commands on all the units which resulted in error on non-leader unit. So change the logic to run configure ceph steps on leader unit only.

Fixes https://github.com/canonical/charm-microceph/issues/74

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [ ] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.
