### PR TITLE
Add config option enable-rgw

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Get actionutils
         run: |
-          curl -sL https://raw.githubusercontent.com/canonical/microceph/main/tests/scripts/actionutils.sh -o ~/actionutils.sh
+          curl -sL https://raw.githubusercontent.com/hemanthnakkina/microceph/wait-for-rgw/tests/scripts/actionutils.sh -o ~/actionutils.sh
           chmod +x ~/actionutils.sh
 
       - name: Upgrade to locally built charm
@@ -111,6 +111,12 @@ jobs:
           sudo microceph.ceph -s
           ~/actionutils.sh wait_for_osds 3
           sudo microceph.ceph -s
+
+      - name: Enable RGW
+        run: |
+          set -eux
+          juju config microceph enable-rgw=True
+          ~/actionutils.sh wait_for_rgw 1
 
   juju-cluster-test:
     needs:

--- a/config.yaml
+++ b/config.yaml
@@ -14,3 +14,9 @@ options:
       The default replication factor for pools. Note that changing
       this value only sets the default value; it doesn't change
       the replication factor for existing pools.
+  enable-rgw:
+    default: False
+    type: boolean
+    description: |
+      Setting this parameter to true enables ceph rados gateway
+      on all the storage nodes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
 select = ["E", "W", "F", "C", "N", "R", "D", "H"]
 # Ignore W503, E501 because using black creates errors with this
 # Ignore D107 Missing docstring in __init__
-ignore = ["W503", "E501", "D107"]
+ignore = ["W503", "E501", "D107", "N818"]
 # D100, D101, D102, D103: Ignore missing docstrings in tests
 per-file-ignores = ["tests/*:D100,D101,D102,D103,D104"]
 docstring-convention = "google"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,10 @@ netifaces
 jsonschema
 tenacity
 jinja2
-requests
+requests<2.32
 git+https://opendev.org/openstack/sunbeam-charms/#egg=ops-sunbeam&subdirectory=ops-sunbeam
+
+# Used for communication with snapd socket
+requests-unixsocket # Apache 2
+urllib3<2 # https://github.com/psf/requests/issues/6432
+

--- a/src/clusterclient.py
+++ b/src/clusterclient.py
@@ -1,0 +1,169 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""The cluster client module to interact with microceph cluster.
+
+The client module can interact over unix socket or http. This
+module can be used to manage microceph cluster. All the operations
+on microceph can be performed using this module.
+"""
+
+import logging
+from abc import ABC
+from typing import List
+from urllib.parse import quote
+
+import requests_unixsocket
+import urllib3
+from requests.exceptions import ConnectionError, HTTPError
+from requests.sessions import Session
+
+LOG = logging.getLogger(__name__)
+MICROCEPH_SOCKET = "/var/snap/microceph/common/state/control.socket"
+
+
+class RemoteException(Exception):
+    """An Exception raised when interacting with the remote microclusterd service."""
+
+    pass
+
+
+class ClusterServiceUnavailableException(RemoteException):
+    """Raised when cluster service is not yet bootstrapped."""
+
+    pass
+
+
+class ServiceNotFoundException(RemoteException):
+    """Raised when ceph service is not found."""
+
+    pass
+
+
+class BaseService(ABC):
+    """BaseService is the base service class for microclusterd services."""
+
+    def __init__(self, session: Session, endpoint: str):
+        """Creates a new BaseService for the  microceph daemon API.
+
+        The service class is used to provide convenient APIs for clients to
+        use when interacting with the microceph daemon api.
+
+
+        :param session: session to use when interacting with the microceph daemon API
+        :type: Session
+        """
+        self.__session = session
+        self._endpoint = endpoint
+
+    def _request(self, method, path, **kwargs):
+        if path.startswith("/"):
+            path = path[1:]
+        netloc = self._endpoint
+        url = f"{netloc}/{path}"
+
+        try:
+            LOG.debug("[%s] %s, args=%s", method, url, kwargs)
+            response = self.__session.request(method=method, url=url, **kwargs)
+            LOG.debug("Response(%s) = %s", response, response.text)
+        except ConnectionError as e:
+            msg = str(e)
+            if "FileNotFoundError" in msg:
+                raise ClusterServiceUnavailableException(
+                    "Microceph Cluster socket not found, is clusterd running ?"
+                    " Check with 'snap services microceph.daemon'",
+                ) from e
+            raise ClusterServiceUnavailableException(msg)
+
+        try:
+            response.raise_for_status()
+        except HTTPError as e:
+            # Do some nice translating to microcephd exceptions
+            error = response.json().get("error")
+            LOG.warning(error)
+            if 'failed to remove service from db "rgw": Service not found' in error:
+                raise ServiceNotFoundException("RGW Service not found")
+            else:
+                raise e
+
+        return response.json()
+
+    def _get(self, path, **kwargs):
+        kwargs.setdefault("allow_redirects", True)
+        return self._request("get", path, **kwargs)
+
+    def _head(self, path, **kwargs):
+        kwargs.setdefault("allow_redirects", False)
+        return self._request("head", path, **kwargs)
+
+    def _post(self, path, data=None, json=None, **kwargs):
+        return self._request("post", path, data=data, json=json, **kwargs)
+
+    def _patch(self, path, data=None, **kwargs):
+        return self._request("patch", path, data=data, **kwargs)
+
+    def _put(self, path, data=None, **kwargs):
+        return self._request("put", path, data=data, **kwargs)
+
+    def _delete(self, path, **kwargs):
+        return self._request("delete", path, **kwargs)
+
+    def _options(self, path, **kwargs):
+        kwargs.setdefault("allow_redirects", True)
+        return self._request("options", path, **kwargs)
+
+
+class Client:
+    """A client for interacting with the remote client API."""
+
+    def __init__(self, endpoint: str):
+        super(Client, self).__init__()
+        self._endpoint = endpoint
+        self._session = Session()
+        if self._endpoint.startswith("http+unix://"):
+            self._session.mount(
+                requests_unixsocket.DEFAULT_SCHEME, requests_unixsocket.UnixAdapter()
+            )
+        else:
+            # TODO(gboutry): remove this when proper TLS communication is
+            # implemented
+            urllib3.disable_warnings()
+            self._session.verify = False
+
+        self.cluster = ClusterService(self._session, self._endpoint)
+
+    @classmethod
+    def from_socket(cls) -> "Client":
+        """Return a client initialized to the clusterd socket."""
+        escaped_socket_path = quote(MICROCEPH_SOCKET, safe="")
+        return cls("http+unix://" + escaped_socket_path)
+
+    @classmethod
+    def from_http(cls, endpoint: str) -> "Client":
+        """Return a client initialized to the clusterd http endpoint."""
+        return cls(endpoint)
+
+
+class ClusterService(BaseService):
+    """Lists and manages cluster.
+
+    TODO(team): Add bootstrap and other commands in microceph and use the
+    socket API calls instead of subprocess.
+    """
+
+    def list_services(self) -> List[str]:
+        """List all services."""
+        services = self._get("/1.0/services")
+        return services.get("metadata")

--- a/src/microceph.py
+++ b/src/microceph.py
@@ -24,6 +24,8 @@ from typing import Tuple
 
 import requests
 
+from clusterclient import Client
+
 logger = logging.getLogger(__name__)
 
 MAJOR_VERSIONS = {
@@ -83,6 +85,21 @@ def is_cluster_member(hostname: str) -> bool:
             raise e
 
 
+def is_rgw_enabled(hostname: str) -> bool:
+    """Check if RGW service is enabled on host.
+
+    Raises ClusterServiceUnavailableException if cluster is not available.
+    """
+    client = Client.from_socket()
+    services = client.cluster.list_services()
+    print(services)
+    for service in services:
+        if service["service"] == "rgw" and service["location"] == hostname:
+            return True
+
+    return False
+
+
 def bootstrap_cluster(micro_ip: str = None, public_net: str = None, cluster_net: str = None):
     """Bootstrap MicroCeph cluster."""
     cmd = ["microceph", "cluster", "bootstrap"]
@@ -107,6 +124,18 @@ def join_cluster(token: str, micro_ip: str = None, **kwargs):
         cmd.extend(["--microceph-ip", micro_ip])
 
     _run_cmd(cmd=cmd)
+
+
+def enable_rgw() -> None:
+    """Enable RGW service."""
+    cmd = ["microceph", "enable", "rgw"]
+    _run_cmd(cmd)
+
+
+def disable_rgw() -> None:
+    """Disable RGW service."""
+    cmd = ["microceph", "disable", "rgw"]
+    _run_cmd(cmd)
 
 
 # Disk CMDs and Helpers

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -49,12 +49,14 @@ class TestCharm(test_utils.CharmTestCase):
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
 
+    @patch.object(microceph, "Client")
     @patch.object(microceph, "subprocess")
-    def test_all_relations(self, subprocess):
+    def test_all_relations(self, subprocess, cclient):
         """Test all the charms relations."""
         self.harness.set_leader()
         self.harness.update_config({"snap-channel": "1.0/stable"})
         test_utils.add_complete_peer_relation(self.harness)
+        cclient().cluster.list_services.return_value = []
         subprocess.run.assert_any_call(
             [
                 "microceph",
@@ -66,6 +68,43 @@ class TestCharm(test_utils.CharmTestCase):
                 "10.0.0.0/24",
                 "--microceph-ip",
                 "10.0.0.10",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=180,
+        )
+
+    @patch.object(microceph, "Client")
+    @patch.object(microceph, "subprocess")
+    def test_all_relations_with_enable_rgw_config(self, subprocess, cclient):
+        """Test all the charms relations."""
+        self.harness.set_leader()
+        self.harness.update_config({"snap-channel": "1.0/stable", "enable-rgw": True})
+        test_utils.add_complete_peer_relation(self.harness)
+        cclient().cluster.list_services.return_value = []
+        subprocess.run.assert_any_call(
+            [
+                "microceph",
+                "cluster",
+                "bootstrap",
+                "--public-network",
+                "10.0.0.0/24",
+                "--cluster-network",
+                "10.0.0.0/24",
+                "--microceph-ip",
+                "10.0.0.10",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=180,
+        )
+        subprocess.run.assert_any_call(
+            [
+                "microceph",
+                "enable",
+                "rgw",
             ],
             capture_output=True,
             text=True,


### PR DESCRIPTION
# Description

Add new option enable-rgw. If the option is
true, enable the rgw on all microceph nodes.

Add cluster client to interact with microceph
daemon over unix socket. For now, add a function
to get all services from the cluster. In future,
this client can be enhanced to bootstrap the
cluster, join new nodes etc.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested using juju bundle on manual controller.

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
- [x] added tests to verify effectiveness of this change.
