### PR TITLE
Add missing rgw configs

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -484,6 +484,8 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
             "rgw_keystone_service_token_enabled",
             "rgw_keystone_service_token_accepted_roles",
             "rgw_s3_auth_use_keystone",
+            "rgw_swift_account_in_url",
+            "rgw_keystone_implicit_tenants",
         ]
 
         logger.info("Removing RGW Cluster configs")
@@ -513,6 +515,14 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
                     "rgw_keystone_service_token_accepted_roles": self.id_svc.interface.admin_role,
                     "rgw_s3_auth_use_keystone": str(True).lower(),
                 }
+                namespace_projects = self.leader_get("namespace-projects")
+                if namespace_projects and json.loads(namespace_projects):
+                    configs.update(
+                        {
+                            "rgw_swift_account_in_url": str(True).lower(),
+                            "rgw_keystone_implicit_tenants": str(True).lower(),
+                        }
+                    )
                 logger.info("Updating RGW Cluster configs")
                 microceph.update_cluster_configs(configs)
             except (AttributeError, KeyError) as e:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -175,6 +175,52 @@ class TestCharm(test_utils.CharmTestCase):
         # Verify if update_config for RGW configs is called
         self.assertEqual(cclient.from_socket().cluster.update_config.call_count, 13)
 
+    @patch.object(microceph, "Client")
+    @patch.object(microceph, "subprocess")
+    @patch("builtins.open", new_callable=mock_open, read_data="mon host dummy-ip")
+    def test_all_relations_with_enable_rgw_config_and_namespace_projects(
+        self, mock_file, subprocess, cclient
+    ):
+        """Test all the charms relations."""
+        self.harness.set_leader()
+        self.harness.update_config(
+            {"snap-channel": "1.0/stable", "enable-rgw": "*", "namespace-projects": True}
+        )
+        test_utils.add_complete_peer_relation(self.harness)
+        self.add_complete_identity_relation(self.harness)
+        self.add_complete_ingress_relation(self.harness)
+        cclient().cluster.list_services.return_value = []
+        subprocess.run.assert_any_call(
+            [
+                "microceph",
+                "cluster",
+                "bootstrap",
+                "--public-network",
+                "10.0.0.0/24",
+                "--cluster-network",
+                "10.0.0.0/24",
+                "--microceph-ip",
+                "10.0.0.10",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=180,
+        )
+        subprocess.run.assert_any_call(
+            [
+                "microceph",
+                "enable",
+                "rgw",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=180,
+        )
+        # Verify if update_config for RGW configs is called
+        self.assertEqual(cclient.from_socket().cluster.update_config.call_count, 15)
+
     @patch.object(microceph, "subprocess")
     @patch("ceph.check_output")
     def test_add_osds_action_with_device_id(self, _chk, subprocess):


### PR DESCRIPTION
Add RGW configs rgw_swift_account_in_url,
rgw_keystone_implicit_tenants when
namespace-projects is True.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Unit test is added.

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [ ] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [x] added tests to verify effectiveness of this change.
